### PR TITLE
add untracked, unused internal dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ instructor
 fastapi
 pydantic
 uvicorn
+anthropic


### PR DESCRIPTION
Adds the Anthropic pypi package since the server will not run without it ( causes an internal error in instructor).

This requirement should be removed when this dependency is removed from the core of instructor or it is brought on as a sub depencacy for instructor.